### PR TITLE
Show submenu arrows on hover

### DIFF
--- a/classicpress-susty-child/style.css
+++ b/classicpress-susty-child/style.css
@@ -365,6 +365,9 @@ table.cp-file-list .cp-file-size {
 		display: inline-block;
 		vertical-align: middle;
 	}
+	.menu-item-has-children > a:hover:after {
+		border-top: 6px solid #040402;
+	}
 	input[type="search"] {
 		max-width: 100%;
 		padding: 1.5em;


### PR DESCRIPTION
From https://github.com/ClassicPress/ClassicPress-Themes/issues/9#issuecomment-437755935

This PR changes the menu styles so that the submenu arrow shows on hover.

> <img width="300" src="https://user-images.githubusercontent.com/227022/48327694-1faa8680-e60e-11e8-82a4-dbb179e4a1ef.png">

On hover, this arrow is absent before this PR.

(Having some issues with styling on this test site, which is making the menu show vertically instead of horizontally.  That's not the important part here.)